### PR TITLE
initial test cases for Dice.

### DIFF
--- a/.launchConfigurations/SkunkApp.launch
+++ b/.launchConfigurations/SkunkApp.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/SkunkProject/src/SkunkApp.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="SkunkApp"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="SkunkProject"/>
+</launchConfiguration>

--- a/.launchConfigurations/TestDie.launch
+++ b/.launchConfigurations/TestDie.launch
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/SkunkProject"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<listAttribute key="org.eclipse.eclemma.core.SCOPE_IDS">
+<listEntry value="=SkunkProject/src"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=SkunkProject"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+<listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8&quot; javaProject=&quot;SkunkProject&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry path=&quot;3&quot; projectName=&quot;SkunkProject&quot; type=&quot;1&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/stdlib.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/apiguardian-api-1.0.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-4.12.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-jupiter-api-5.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-jupiter-engine-5.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-jupiter-params-5.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-commons-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-console-standalone-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-engine-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-launcher-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-runner-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-platform-suite-api-1.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/junit-vintage-engine-5.4.0.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/opentest4j-1.1.1.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/stdlib-package.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/SkunkProject/lib/hamcrest-core-1.3.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="SkunkProject"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+</launchConfiguration>

--- a/SkunkProject/test/TestDice.java
+++ b/SkunkProject/test/TestDice.java
@@ -1,0 +1,99 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TestDice {
+
+	static int rolls = 10000;
+
+	@Test
+	public void dice_roll_is_always_greater_than_two_and_less_than_thirteen()
+	{
+		Dice dice = new Dice();
+		for (int i = 0; i < rolls; i++) {
+			dice.roll();
+			assertTrue(dice.getLastRoll() > 1, "Last dice roll was <= 2");
+			assertTrue(dice.getLastRoll() < 13, "Last dice roll was >= 13");
+		}
+	}
+
+	@Test
+	public void when_the_dice_are_rolled_it_is_reasonably_random()
+	{
+		Dice dice = new Dice();
+		int two_count = 0;
+		int three_count = 0;
+		int four_count = 0;
+		int five_count = 0;
+		int six_count = 0;
+		int seven_count = 0;
+		int eight_count = 0;
+		int nine_count = 0;
+		int ten_count = 0;
+		int eleven_count = 0;
+		int twelve_count = 0;
+		
+		for (int i = 0; i < rolls; i++) {
+			dice.roll();
+			switch (dice.getLastRoll()) {
+			case 2:
+				two_count += 1;
+				break;
+			case 3:
+				three_count += 1;
+				break;
+			case 4:
+				four_count += 1;
+				break;
+			case 5:
+				five_count += 1;
+				break;
+			case 6:
+				six_count += 1;
+				break;
+			case 7:
+				seven_count += 1;
+				break;
+			case 8:
+				eight_count += 1;
+				break;
+			case 9:
+				nine_count += 1;
+				break;
+			case 10:
+				ten_count += 1;
+				break;
+			case 11:
+				eleven_count += 1;
+				break;
+			case 12:
+				twelve_count += 1;
+				break;
+			}
+		}
+		
+		assertTrue(two_count >= 0, "Two was less than the expected rolls.");
+		assertTrue(two_count <= rolls/36*2, "Two was greater than the expected rolls.");
+		assertTrue(three_count >= rolls/36, "Three was less than the expected rolls.");
+		assertTrue(three_count <= rolls/36*3, "Three was greater than the expected rolls.");
+		assertTrue(four_count >= rolls/36*2, "Four was less than the expected rolls.");
+		assertTrue(four_count <= rolls/36*4, "Four was greater than the expected rolls.");
+		assertTrue(five_count >= rolls/36*3, "Five was less than the expected rolls.");
+		assertTrue(five_count <= rolls/36*5, "Five was greater than the expected rolls.");
+		assertTrue(six_count >= rolls/36*4, "Six was less than the expected rolls.");
+		assertTrue(six_count <= rolls/36*6, "Six was greater than the expected rolls.");
+		assertTrue(seven_count >= rolls/36*5, "Seven was less than the expected rolls.");
+		assertTrue(seven_count <= rolls/36*7, "Seven was greater than the expected rolls.");
+		assertTrue(eight_count >= rolls/36*4, "Eight was less than the expected rolls.");
+		assertTrue(eight_count <= rolls/36*6, "Eight was greater than the expected rolls.");
+		assertTrue(nine_count >= rolls/36*3, "Nine was less than the expected rolls.");
+		assertTrue(nine_count <= rolls/36*5, "Nine was greater than the expected rolls.");
+		assertTrue(ten_count >= rolls/36*2, "Ten was less than the expected rolls.");
+		assertTrue(ten_count <= rolls/36*4, "Ten was greater than the expected rolls.");
+		assertTrue(eleven_count >= rolls/36, "Eleven was less than the expected rolls.");
+		assertTrue(eleven_count <= rolls/36*3, "Eleven was greater than the expected rolls.");
+		assertTrue(twelve_count >= 0, "Twelve was less than the expected rolls.");
+		assertTrue(twelve_count <= rolls/36*2, "Twelve was greater than the expected rolls.");
+	}
+
+}


### PR DESCRIPTION
Covers the randomness and value bounds test cases for Dice.

@jlie1803 I would like you to implement the remaining test cases that cover the Dice class.

This includes:
* `when_initialized_with_two_mocked_dice_expected_roll_is_returned`

This test case should evaluate all the reasonable Die combinations for a pair of dice and should verify that the numeric and string representations of the class are what you expect.

Here's a good chart of the 36 outcomes you can get with a roll of two dice.

http://andymath.com/probability-with-dice/